### PR TITLE
Stop calc value for font-size failing in production.

### DIFF
--- a/dc_theme/static/dc_theme/scss/dc/_fonts.scss
+++ b/dc_theme/static/dc_theme/scss/dc/_fonts.scss
@@ -6,7 +6,7 @@ body {
     font-smoothing: antialiased;
     font-variant-ligatures: common-ligatures;
     color:$body-text-colour;
-    font-size: calc(1.14em + 0.3vw);
+    font-size: calc((1.14em) + 0.3vw);
     line-height: 1.58;
 }
 

--- a/dc_theme/templates/dc_base.html
+++ b/dc_theme/templates/dc_base.html
@@ -24,7 +24,7 @@
   {#   </div> #}
   {#   {% endfor %} #}
   {# {% endif %} #}
-  {# {% block top_banner %}{% endblock top_banner %} #}
+  {% block top_banner %}{% endblock top_banner %}
 
 
   <main>


### PR DESCRIPTION
Add parentheses so `calc` value is not invalid once whitespace stripped.

Fix for https://github.com/DemocracyClub/WhoCanIVoteFor/issues/179