### PR TITLE
only generate one label tag for fields with auto_id prop (v0.2)

### DIFF
--- a/dc_theme/templates/dc_forms/field.html
+++ b/dc_theme/templates/dc_forms/field.html
@@ -1,6 +1,6 @@
 {% load dc_forms %}
 <div class="form-group{% if field.errors %} has-error{% endif %}">
-    {% if not field|is_heading %}
+    {% if not field|is_heading and not field.auto_id %}
         <label {% if field.field.required and form.required_css_class %}class="form-label-bold {{ form.required_css_class }}"{% endif %}>
             {{ field.label }}
             {% if field.help_text %}


### PR DESCRIPTION
Closes #15 (for version 0.2).

Note that I've created a new branch `v0.2`, reset it to e4dc67c and targetted this PR at that branch. This will allow us to update EE's [theme dependency](https://github.com/DemocracyClub/EveryElection/blob/master/requirements/base.txt#L12) to reference the `v0.2` branch on this repo so I can progress https://github.com/DemocracyClub/EveryElection/pull/62 without having to do a full theme upgrade.