### PR TITLE
[v0.2] switch django-pipeline dependency to range

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(name='DC Base Theme',
           'https://github.com/mysociety/django-pipeline-csscompressor/archive/master.zip==master',
       ],
       install_requires=[
-          'django-pipeline==1.6.9',
+          'django-pipeline>=1.6.8,<2.0',
           'libsass==0.11.1',
       ]
-      )
+)


### PR DESCRIPTION
On EveryElection (the only project where we're still using the 0.2 theme), we need to use this theme and https://github.com/mysociety/django-pipeline-csscompressor/

Pinning `django-pipeline==1.6.9` gives us a dependency conflict with `django-pipeline-csscompressor` (even though there is no reason to use specifically version 1.6.9). Switching to a range will remove conflict.