### PR TITLE
Add wheel requirement to setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,4 +56,5 @@ setup(
         'jsmin==2.2.2',
 
     ],
+    setup_requires=['wheel']
 )


### PR DESCRIPTION
I was getting `ERROR: Failed building wheel for DC-Base-Theme` when I tried to install this. I think this should fix it. 