### PR TITLE
Fix missing template vars errors

### DIFF
--- a/dc_theme/templates/500.html
+++ b/dc_theme/templates/500.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block page_title %}Server Error{% endblock %}
 

--- a/dc_theme/templates/dc_base.html
+++ b/dc_theme/templates/dc_base.html
@@ -1,6 +1,6 @@
 {% extends "dc_base_naked.html" %}
 
-{% load staticfiles %}
+{% load static %}
 
 {% block body_base %}
   {% block header %}

--- a/dc_theme/templates/dc_base_naked.html
+++ b/dc_theme/templates/dc_base_naked.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<!doctype html>
+{% load static %}<!doctype html>
 <html class="no-js" lang="{{LANGUAGE_CODE}}">
   <head>
     <meta charset="utf-8">

--- a/dc_theme/templates/dc_forms/field.html
+++ b/dc_theme/templates/dc_forms/field.html
@@ -1,7 +1,7 @@
 {% load dc_forms %}
 <div class="form-group{% if field.errors %} has-error{% endif %}">
   {% if not field|is_heading and not field.auto_id %}
-  <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}">
+  <label class="control-label {{ classes.label }} {% if field.field.required and form.required_css_class %}{{ form.required_css_class }}{% endif %}">
       {{ field.label }}
       {% if field.help_text %}
         <span class="form-hint">{{ field.help_text }}</span>
@@ -13,7 +13,7 @@
       <div class="checkbox">
         {{ field }}
         {% if field.auto_id %}
-          <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}" for="{{ field.auto_id }}">
+          <label class="control-label {{ classes.label }} {% if field.field.required and form.required_css_class %}{{ form.required_css_class }}{% endif %}" for="{{ field.auto_id }}">
             {{ field.label }}
           </label>
         {% endif %}
@@ -31,7 +31,7 @@
 
   {% elif field|is_radio %}
     {% if field.auto_id %}
-      <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}">{{ field.label }}</label>
+      <label class="control-label {{ classes.label }} {% if field.field.required and form.required_css_class %}{{ form.required_css_class }}{% endif %}">{{ field.label }}</label>
     {% endif %}
     <div class="{{ classes.value }}">
       {% for choice in field %}
@@ -57,7 +57,7 @@
     <h2 id="{{field.auto_id}}">{{ field.label }}</h2>
   {% else %}
     {% if field.auto_id %}
-      <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class }}{% endif %}" for="{{ field.auto_id }}">
+      <label class="control-label {{ classes.label }} {% if field.field.required and form.required_css_class %}{{ form.required_css_class }}{% endif %}" for="{{ field.auto_id }}">
         {{ field.label }}
         {% for error in field.errors %}
           <span class="error-help-text {{ form.error_css_class }}">{{ error }}</span>

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ for dirpath, dirnames, filenames in os.walk(app_dir):
 
 setup(
     name='DC Base Theme',
-    version='0.3.12',
+    version='0.3.13',
     description='Base assets for DC projects',
     author='Sym Roe',
     author_email='sym.roe@democracyclub.org.uk',


### PR DESCRIPTION
- Add conditional to check for required_css_class attr on a form
- Use 'static' rather than 'staticfiles' templatetag to resolve
removed in django 3 deprecation warnings
- Bump minor version to 0.3.13

Co-authored-by: name <virginia.dooley@democracyclub.org.uk>
Co-authored-by: name <michaeljcollinsuk@users.noreply.github.com>