### PR TITLE
Package name shouldn't have spaces in it

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ for dirpath, dirnames, filenames in os.walk(app_dir):
 
 
 setup(
-    name='DC Base Theme',
+    name='dc-base-theme',
     version='0.3.12',
     description='Base assets for DC projects',
     author='Sym Roe',


### PR DESCRIPTION
The package name should probably be `dc-base-theme` instead of `DC Base Theme`